### PR TITLE
DISCOURSE_ADDITIONAL_PLUGINS build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DISCOURSE_VERSION=1.7.0.beta3 \
     DISCOURSE_SERVE_STATIC_ASSETS=true \
     GIFSICLE_VERSION=1.87 \
     PNGQUANT_VERSION=2.4.1
-    
+
 RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - \
  && apt-get update && apt-get install -y --no-install-recommends \
       autoconf \
@@ -46,7 +46,7 @@ RUN git clone --branch v${DISCOURSE_VERSION} https://github.com/discourse/discou
  && git remote set-branches --add origin tests-passed \
  && bundle config build.nokogiri --use-system-libraries \
  && bundle install --deployment --without test --without development
- 
+
 
 # install discourse plugins
 # assumptions: no spaces in URLs (urlencoding is a thing)

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,6 @@ RUN if [ "$DISCOURSE_ADDITIONAL_PLUGINS" != "" ]; then \
         for PACKAGE_LINK in $DISCOURSE_ADDITIONAL_PLUGINS; do \
             git clone "$PACKAGE_LINK"; \
         done; \
-        bundle exec rake plugin:update plugin=discourse-plugin-checklist; \
-        bundle exec rake assets:clean; \
     fi
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,12 @@ RUN git clone --branch v${DISCOURSE_VERSION} https://github.com/discourse/discou
 # this expects a git-cloneable link
 ARG DISCOURSE_ADDITIONAL_PLUGINS=
 RUN if [ "$DISCOURSE_ADDITIONAL_PLUGINS" != "" ]; then \
-        cd plugins/ \
+        cd plugins/; \
         for PACKAGE_LINK in $DISCOURSE_ADDITIONAL_PLUGINS; do \
             git clone "$PACKAGE_LINK"; \
         done; \
         bundle exec rake plugin:update plugin=discourse-plugin-checklist; \
         bundle exec rake assets:clean; \
-        bundle exec rake assets:precompile; \
     fi
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # docker-discourse
+
 discourse image for discourse service
+
+## Discourse plugins
+
+This image supports installing Discourse plugins at build time, via the `DISCOURSE_ADDITIONAL_PLUGINS` [build arg](https://docs.docker.com/engine/reference/builder/#/arg). Set it to a whitespace (space, tab, newline) separated list if valid `git` URLs of plugins to be installed at build time.


### PR DESCRIPTION
Adding the possibility of installing (at build time) Discourse plugins specified in `DISCOURSE_ADDITIONAL_PLUGINS` build arg as `git` URLs.