### PR TITLE
Support for DISCOURSE_ADDITIONAL_GEMS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,10 @@ RUN git clone --branch v${DISCOURSE_VERSION} https://github.com/discourse/discou
 # this expects a space-separated list of gem names
 ARG DISCOURSE_ADDITIONAL_GEMS=
 RUN if [ "$DISCOURSE_ADDITIONAL_GEMS" != "" ]; then \
-        echo >> Gemfile \
-        echo '### DISCOURSE_ADDITIONAL_GEMS' >> Gemfile \
+        echo >> Gemfile ; \
+        echo '### DISCOURSE_ADDITIONAL_GEMS' >> Gemfile ; \
         for GEM_NAME in $DISCOURSE_ADDITIONAL_GEMS; do \
-            # add the gem to the Gemfile
-            echo "gem \"$GEM_NAME\"" >> Gemfile; \
+            echo "gem \"$GEM_NAME\"" >> Gemfile ; \
         done; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,12 @@ RUN if [ "$DISCOURSE_ADDITIONAL_GEMS" != "" ]; then \
     fi
 
 # run bundler
-#RUN bundle install --deployment --without test --without development
-RUN bundle install --without test --without development
+# deployment mode if no new gems added, normal mode otherwise
+RUN if [ "$DISCOURSE_ADDITIONAL_GEMS" != "" ]; then \
+        bundle install --without test --without development; \
+    else \
+        bundle install --deployment --without test --without development; \
+    fi
     
 # install discourse plugins
 # assumptions: no spaces in URLs (urlencoding is a thing)

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ RUN if [ "$DISCOURSE_ADDITIONAL_GEMS" != "" ]; then \
     fi
 
 # run bundler
-RUN bundle install --deployment --without test --without development
+#RUN bundle install --deployment --without test --without development
+RUN bundle install --without test --without development
     
 # install discourse plugins
 # assumptions: no spaces in URLs (urlencoding is a thing)

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,15 @@ RUN git clone --branch v${DISCOURSE_VERSION} https://github.com/discourse/discou
  && bundle config build.nokogiri --use-system-libraries \
  && bundle install --deployment --without test --without development
 
+# install additional gems
+# 
+# this expects a space-separated list of gem names
+ARG DISCOURSE_ADDITIONAL_GEMS=
+RUN if [ "$DISCOURSE_ADDITIONAL_GEMS" != "" ]; then \
+        for GEM_NAME in $DISCOURSE_ADDITIONAL_GEMS; do \
+            bundle exec gem install "$GEM_NAME"; \
+        done; \
+    fi
 
 # install discourse plugins
 # assumptions: no spaces in URLs (urlencoding is a thing)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,19 +44,24 @@ RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - \
 
 RUN git clone --branch v${DISCOURSE_VERSION} https://github.com/discourse/discourse.git . \
  && git remote set-branches --add origin tests-passed \
- && bundle config build.nokogiri --use-system-libraries \
- && bundle install --deployment --without test --without development
+ && bundle config build.nokogiri --use-system-libraries
 
 # install additional gems
 # 
 # this expects a space-separated list of gem names
 ARG DISCOURSE_ADDITIONAL_GEMS=
 RUN if [ "$DISCOURSE_ADDITIONAL_GEMS" != "" ]; then \
+        echo >> Gemfile \
+        echo '### DISCOURSE_ADDITIONAL_GEMS' >> Gemfile \
         for GEM_NAME in $DISCOURSE_ADDITIONAL_GEMS; do \
-            bundle exec gem install "$GEM_NAME"; \
+            # add the gem to the Gemfile
+            echo "gem \"$GEM_NAME\"" >> Gemfile; \
         done; \
     fi
 
+# run bundler
+RUN bundle install --deployment --without test --without development
+    
 # install discourse plugins
 # assumptions: no spaces in URLs (urlencoding is a thing)
 # 


### PR DESCRIPTION
Some Discourse plugins require additional Ruby gems to be installed. This pull request introduces `DISCOURSE_ADDITIONAL_GEMS` docker build argument for exactly this purpose.