### PR TITLE
PNGQUANT_VERSION, GIFSICLE_VERSION, DISCOURSE_VERSION as build args, not envvars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@ FROM rails
 
 WORKDIR /usr/src/app
 
-ENV DISCOURSE_VERSION=1.7.0.beta3 \
-    RAILS_ENV=production \
+ARG DISCOURSE_VERSION=1.7.0.beta3
+ARG GIFSICLE_VERSION=1.87
+ARG PNGQUANT_VERSION=2.4.1
+
+ENV RAILS_ENV=production \
     RUBY_GC_MALLOC_LIMIT=90000000 \
     RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 \
     DISCOURSE_DB_HOST=postgres \
     DISCOURSE_REDIS_HOST=redis \
-    DISCOURSE_SERVE_STATIC_ASSETS=true \
-    GIFSICLE_VERSION=1.87 \
-    PNGQUANT_VERSION=2.4.1
+    DISCOURSE_SERVE_STATIC_ASSETS=true
 
 RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - \
  && apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@ FROM rails
 
 WORKDIR /usr/src/app
 
-ARG DISCOURSE_VERSION=1.7.0.beta3
-ARG GIFSICLE_VERSION=1.87
-ARG PNGQUANT_VERSION=2.4.1
-
 ENV RAILS_ENV=production \
     RUBY_GC_MALLOC_LIMIT=90000000 \
     RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 \
     DISCOURSE_DB_HOST=postgres \
     DISCOURSE_REDIS_HOST=redis \
     DISCOURSE_SERVE_STATIC_ASSETS=true
+
+ARG GIFSICLE_VERSION=1.87
+ARG PNGQUANT_VERSION=2.4.1
 
 RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - \
  && apt-get update && apt-get install -y --no-install-recommends \
@@ -42,6 +41,8 @@ RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - \
  && npm install svgo uglify-js -g \
  && rm -fr /tmp/* \
  && rm -rf /var/lib/apt/lists/*
+
+ARG DISCOURSE_VERSION=1.7.0.beta3
 
 RUN git clone --branch v${DISCOURSE_VERSION} https://github.com/discourse/discourse.git . \
  && git remote set-branches --add origin tests-passed \


### PR DESCRIPTION
`PNGQUANT_VERSION`, `GIFSICLE_VERSION`, `DISCOURSE_VERSION` are all used in the build phase. Thus, they should be [build args](https://docs.docker.com/engine/reference/builder/#arg), not [envvars](https://docs.docker.com/engine/reference/builder/#env).